### PR TITLE
Added inLanguage to MediaObject fields, both in mutations and queries

### DIFF
--- a/tests/data/mediaobject/create_mediaobject.txt
+++ b/tests/data/mediaobject/create_mediaobject.txt
@@ -10,6 +10,7 @@ name: "Rossinyol"
         source: "https://www.cpdl.org/wiki/index.php/Rossinyol"
         subject: "Catalan choir piece"
         contentUrl: "https://www.cpdl.org/wiki/index.php/Rossinyol"
+        inLanguage: "ca"
         language: en
 ) {
 identifier

--- a/tests/test_mediaobject.py
+++ b/tests/test_mediaobject.py
@@ -17,7 +17,8 @@ class TestDocument(unittest.TestCase):
 
         created_mediaobject = mediaobject.mutation_create_media_object(name="Rossinyol", description="Traditional choir piece", date="1972", creator="trompamusic.eu",\
         contributor="www.upf.edu", format_="text/html", encodingFormat="text/html", source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", \
-        contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="en")
+        contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="en", inLanguage="ca")
+        print(created_mediaobject)
         self.assertEqual(created_mediaobject, expected)
 
     def test_update_name(self):
@@ -64,7 +65,7 @@ class TestDocument(unittest.TestCase):
         with self.assertRaises(UnsupportedLanguageException):
             mediaobject.mutation_create_media_object(name="Rossinyol", description="Traditional choir piece", date="1972", creator="trompamusic.eu",\
         contributor="www.upf.edu", format_="text/html", encodingFormat="text/html", source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", \
-        contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="ja")
+        contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="ja", inLanguage="ca")
 
 
     def test_invalid_format(self):
@@ -75,11 +76,13 @@ class TestDocument(unittest.TestCase):
         with self.assertRaises(NotAMimeTypeException):
             mediaobject.mutation_update_media_object('2eeca6dd-c62c-490e-beb0-2e3899fca74f',name="Rossinyol", description="Traditional choir piece",\
         date="1972", creator="trompamusic.eu", contributor="www.upf.edu", format_="text,html", encodingFormat="text/html",\
-        source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="en")
+        source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol",\
+        language="en", inLanguage="ca")
         with self.assertRaises(NotAMimeTypeException):
             mediaobject.mutation_update_media_object('2eeca6dd-c62c-490e-beb0-2e3899fca74f',name="Rossinyol", description="Traditional choir piece",\
         date="1972", creator="trompamusic.eu", contributor="www.upf.edu", format_="text/html", encodingFormat="text,html",\
-        source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="en")
+        source="https://www.cpdl.org/wiki/index.php/Rossinyol", subject="Catalan choir piece", contentUrl="https://www.cpdl.org/wiki/index.php/Rossinyol", language="en",\
+        inLanguage="ca")
 
     def test_merge_exampleOf(self):
         expected = util.read_file(self.data_dir, "merge_object_encoding.txt")

--- a/trompace/mutations/mediaobject.py
+++ b/trompace/mutations/mediaobject.py
@@ -22,7 +22,7 @@ MEDIAOBJECT_ARGS_DOCS = """name: The name of the media object.
 @docstring_interpolate("mediaobject_args", MEDIAOBJECT_ARGS_DOCS)
 def mutation_create_media_object(name: str, description: str, date: str, creator: str, contributor: str, format_: str,
                                  encodingFormat: str, source: str, subject: str,
-                                 contentUrl: str, language: str, title: str = None):
+                                 contentUrl: str, language: str, inLanguage:str, title: str = None):
     """Returns a mutation for creating a media object object
     Arguments:
         {mediaobject_args}
@@ -52,6 +52,7 @@ def mutation_create_media_object(name: str, description: str, date: str, creator
         "source": source,
         "subject": subject,
         "contentUrl": contentUrl,
+        "inLanguage": inLanguage,
         "language": StringConstant(language.lower())
     }
 
@@ -64,7 +65,7 @@ def mutation_create_media_object(name: str, description: str, date: str, creator
 def mutation_update_media_object(identifier: str, name: str = None, title: str = None, description: str = None,
                                  date: str = None, creator: str = None, contributor: str = None,
                                  format_: str = None, encodingFormat: str = None, source: str = None,
-                                 subject: str = None, contentUrl: str = None, language: str = None):
+                                 subject: str = None, contentUrl: str = None, language: str = None, inLanguage:str = None):
     """Returns a mutation for updating a media object object.
     Arguments:
         identifier: The identifier of the media object in the CE to be updated.
@@ -92,6 +93,7 @@ def mutation_update_media_object(identifier: str, name: str = None, title: str =
         "source": source,
         "subject": subject,
         "contentUrl": contentUrl,
+        "inLanguage": inLanguage,
     }
     if date:
         args["date"] = _Neo4jDate(date)


### PR DESCRIPTION
inLanguage was present in the docstring, but not in the arguments of the function, guess it went missing at some point. Added for both create and update mutations and the queries.