### PR TITLE
Control Action mutations updates needed for TPL

### DIFF
--- a/trompace/mutations/controlaction.py
+++ b/trompace/mutations/controlaction.py
@@ -137,3 +137,10 @@ def mutation_request_controlaction(controlaction_id: str, entrypoint_id: str, pr
         }
     }
     return format_mutation("RequestControlAction", args)
+
+def mutation_update_controlaction(controlaction_id: str, actionStatus: trompace.StringConstant):
+    args = {
+       "identifier": controlaction_id,
+       "actionStatus": actionStatus
+    }
+    return format_mutation("UpdateControlAction", args)

--- a/trompace/mutations/controlaction.py
+++ b/trompace/mutations/controlaction.py
@@ -144,3 +144,7 @@ def mutation_update_controlaction(controlaction_id: str, actionStatus: trompace.
        "actionStatus": actionStatus
     }
     return format_mutation("UpdateControlAction", args)
+
+def mutation_addactioninterfance_result(controlaction_id:str, thing_id:str):
+
+    return format_link_mutation("AddActionInterfaceResult", controlaction_id, thing_id, )

--- a/trompace/mutations/controlaction.py
+++ b/trompace/mutations/controlaction.py
@@ -162,7 +162,7 @@ def mutation_update_controlaction_status(controlaction_id: str, action_status: A
     return format_mutation("UpdateControlAction", args)
 
 
-def mutation_add_actioninterface_result(controlaction_id:str, thing_interface_id:str):
+def mutation_add_actioninterface_result(controlaction_id: str, thing_interface_id: str):
     """Returns a mutation for linking a control action object and a thing interface with the result relation
     Arguments:
         controlaction_id: The unique identifier of the control action.

--- a/trompace/mutations/controlaction.py
+++ b/trompace/mutations/controlaction.py
@@ -147,7 +147,7 @@ def mutation_request_controlaction(controlaction_id: str, entrypoint_id: str, pr
     return format_mutation("RequestControlAction", args)
 
 
-def mutation_update_controlaction_status(controlaction_id: str, action_status: trompace.ActionStatusType):
+def mutation_update_controlaction_status(controlaction_id: str, action_status: ActionStatusType):
     """Returns a mutation for updating the status of a control action to an object
     Arguments:
         controlaction_id: The unique identifier of the control action.

--- a/trompace/mutations/controlaction.py
+++ b/trompace/mutations/controlaction.py
@@ -128,6 +128,14 @@ def mutation_add_controlaction_object(controlaction_id: str, object_id: str):
 
 def mutation_request_controlaction(controlaction_id: str, entrypoint_id: str, properties: list,
                                    propertyValues: list):
+    """Returns a mutation for requesting a control action
+        controlaction_id: The unique identifier of the control action.
+        entrypoint_id: The unique identifier of the entry point linked to this control action
+        properties: a list of the properties objects of the control action
+        propertyValues: a list of the properties objects of the control action
+    Returns:
+        The string for the mutation for requesting a control action.
+        """
     args = {
         "controlAction": {
             "potentialActionIdentifier": controlaction_id,
@@ -138,13 +146,29 @@ def mutation_request_controlaction(controlaction_id: str, entrypoint_id: str, pr
     }
     return format_mutation("RequestControlAction", args)
 
-def mutation_update_controlaction(controlaction_id: str, actionStatus: trompace.StringConstant):
+
+def mutation_update_controlaction_status(controlaction_id: str, action_status: trompace.ActionStatusType):
+    """Returns a mutation for updating the status of a control action to an object
+    Arguments:
+        controlaction_id: The unique identifier of the control action.
+        action_status: the action status enum object.
+    Returns:
+        The string for the mutation for adding a control action to an object.
+        """
     args = {
        "identifier": controlaction_id,
-       "actionStatus": actionStatus
+       "actionStatus": StringConstant(str(action_status))
     }
     return format_mutation("UpdateControlAction", args)
 
-def mutation_addactioninterfance_result(controlaction_id:str, thing_id:str):
 
-    return format_link_mutation("AddActionInterfaceResult", controlaction_id, thing_id, )
+def mutation_add_actioninterface_result(controlaction_id:str, thing_interface_id:str):
+    """Returns a mutation for linking a control action object and a thing interface with the result relation
+    Arguments:
+        controlaction_id: The unique identifier of the control action.
+        thing_interface_id: the unique identifier of a thing interface object
+    Returns:
+        The string for the mutation for adding a control action to an object.
+        """
+
+    return format_link_mutation("AddActionInterfaceResult", controlaction_id, thing_interface_id)

--- a/trompace/queries/controlaction.py
+++ b/trompace/queries/controlaction.py
@@ -1,0 +1,39 @@
+from trompace.exceptions import UnsupportedLanguageException, NotAMimeTypeException
+from trompace.queries.templates import format_query
+from trompace import StringConstant, _Neo4jDate, filter_none_args, docstring_interpolate
+from trompace.constants import SUPPORTED_LANGUAGES
+
+QUERY_CONTROLACTION_ID = """
+    query {{
+        ControlAction(identifier: "{identifier}") {{
+            actionStatus
+            identifier
+            object {{
+                ... on PropertyValue {{
+                    value
+                    name
+                    nodeValue {{
+                        ... on DigitalDocument {{
+                            format
+                            source
+                        }}
+                    }}
+                }}
+            }}
+        }}
+    }}
+"""
+
+
+def query_controlaction(identifier: str = None):
+
+    """Returns a query for querying the database for a controlaction object.
+    Arguments:
+        identifier: The identifier of the media object in the CE.
+
+        The string for the quereing the media object.
+    Raises:
+        UnsupportedLanguageException if the input language is not one of the supported languages.
+    """
+    query_ca = QUERY_CONTROLACTION_ID.format(identifier=identifier)
+    return query_ca

--- a/trompace/queries/controlaction.py
+++ b/trompace/queries/controlaction.py
@@ -26,15 +26,13 @@ QUERY_CONTROLACTION_ID = """
 """
 
 
-def query_controlaction(identifier: str = None):
+def query_controlaction(identifier: str):
 
     """Returns a query for querying the database for a controlaction object.
     Arguments:
-        identifier: The identifier of the media object in the CE.
-
-        The string for the quereing the media object.
-    Raises:
-        UnsupportedLanguageException if the input language is not one of the supported languages.
+        identifier: The identifier of the control action in the CE.
+    Returns:
+        The string for the quereing the control action.
     """
     query_ca = QUERY_CONTROLACTION_ID.format(identifier=identifier)
     return query_ca

--- a/trompace/queries/controlaction.py
+++ b/trompace/queries/controlaction.py
@@ -12,6 +12,7 @@ QUERY_CONTROLACTION_ID = """
                 ... on PropertyValue {{
                     value
                     name
+                    title
                     nodeValue {{
                         ... on DigitalDocument {{
                             format


### PR DESCRIPTION
- hardcoded controlaction queries (to suppost on {} arguments on queries)
- update control action status mutation
- tringinterface_result